### PR TITLE
Update tzsp2pcap.c

### DIFF
--- a/tzsp2pcap.c
+++ b/tzsp2pcap.c
@@ -453,12 +453,12 @@ int main(int argc, char **argv) {
 			my_pcap.postrotate_command = strdup(optarg);
 			break;
 
-		default:
-			retval = -1;
-
 		case 'h':
 			usage(argv[0]);
 			goto exit;
+
+		default:
+			retval = -1;
 		}
 	}
 


### PR DESCRIPTION
"default:" should be the last in the cases otherwise it doesn't compile, at least under ubuntu 18.04.1